### PR TITLE
Improve base time of assert_linear_performance

### DIFF
--- a/lib/core_assertions.rb
+++ b/lib/core_assertions.rb
@@ -825,7 +825,9 @@ eom
         end
         times.compact!
         tmin, tmax = times.minmax
-        tbase = 10 ** Math.log10(tmax * ([(tmax / tmin), 2].max ** 2)).ceil
+
+        # safe_factor * tmax * rehearsal_time_variance_factor(equals to 1 when variance is small)
+        tbase = 10 * tmax * [(tmax / tmin) ** 2 / 4, 1].max
         info = "(tmin: #{tmin}, tmax: #{tmax}, tbase: #{tbase})"
 
         seq.each do |i|


### PR DESCRIPTION
Remove `.ceil` from base time calculation that makes 10x gap. This will make the assertion more strict and also less flaky.

https://github.com/ruby/ruby/pull/11369