### PR TITLE
assert_deprecated_warning: restore `Warning[:deprecated]`

### DIFF
--- a/lib/core_assertions.rb
+++ b/lib/core_assertions.rb
@@ -647,17 +647,15 @@ eom
         assert_warning(*args) {$VERBOSE = false; yield}
       end
 
-      def assert_deprecated_warning(mesg = /deprecated/)
+      def assert_deprecated_warning(mesg = /deprecated/, &block)
         assert_warning(mesg) do
-          Warning[:deprecated] = true if Warning.respond_to?(:[]=)
-          yield
+          EnvUtil.deprecation_warning(&block)
         end
       end
 
       def assert_deprecated_warn(mesg = /deprecated/)
         assert_warn(mesg) do
-          Warning[:deprecated] = true if Warning.respond_to?(:[]=)
-          yield
+          EnvUtil.deprecation_warning(&block)
         end
       end
 

--- a/lib/envutil.rb
+++ b/lib/envutil.rb
@@ -228,7 +228,7 @@ module EnvUtil
   end
   module_function :verbose_warning
 
-  if Warning.respond_to?(:[]=)
+  if defined?(Warning.[]=)
     def deprecation_warning
       previous_deprecated = Warning[:deprecated]
       Warning[:deprecated] = true

--- a/lib/envutil.rb
+++ b/lib/envutil.rb
@@ -228,6 +228,21 @@ module EnvUtil
   end
   module_function :verbose_warning
 
+  if Warning.respond_to?(:[]=)
+    def deprecation_warning
+      previous_deprecated = Warning[:deprecated]
+      Warning[:deprecated] = true
+      yield
+    ensure
+      Warning[:deprecated] = previous_deprecated
+    end
+  else
+    def deprecation_warning
+      yield
+    end
+  end
+  module_function :deprecation_warning
+
   def default_warning
     $VERBOSE = false
     yield


### PR DESCRIPTION
Not a big deal, but ideally we shouldn't leak any state.

cc @hsbt 