### PR TITLE
Fix EnvUtil.invoke_ruby on Ruby < 3.3

### DIFF
--- a/lib/envutil.rb
+++ b/lib/envutil.rb
@@ -225,7 +225,7 @@ module EnvUtil
 
     args = [args] if args.kind_of?(String)
     # use the same parser as current ruby
-    if args.none? { |arg| arg.start_with?("--parser=") }
+    if RUBY_VERSION >= "3.3" && args.none? { |arg| arg.start_with?("--parser=") }
       args = ["--parser=#{current_parser}"] + args
     end
     pid = spawn(child_env, *precommand, rubybin, *args, opt)


### PR DESCRIPTION
Only pass --parser= option to Ruby versions that accept it. test-unit-ruby-core currently supports Ruby >= 2.3.

---

With v1.0.8 assertion methods that spawn child process are broken. For example, https://github.com/ruby/openssl/actions/runs/18215689022/job/51864356336 failed with:

```
[...]
10) Failure: test_unloaded_openssl_provider(OpenSSL::TestProvider):
  assert_separately failed with error message
  pid 2438 exit 1
  | /opt/hostedtoolcache/Ruby/3.2.9/x64/bin/ruby: invalid option --parser=parse.y  (-h will show valid options) (RuntimeError)
[...]
```