### PR TITLE
Set Ruby parser if the given ruby accepts `--parser`

### DIFF
--- a/lib/envutil.rb
+++ b/lib/envutil.rb
@@ -225,7 +225,8 @@ module EnvUtil
 
     args = [args] if args.kind_of?(String)
     # use the same parser as current ruby
-    if args.none? { |arg| arg.start_with?("--parser=") }
+    if (args.none? { |arg| arg.start_with?("--parser=") } and
+        /^ +--parser=/ =~ IO.popen([rubybin, "--help"], &:read))
       args = ["--parser=#{current_parser}"] + args
     end
     pid = spawn(child_env, *precommand, rubybin, *args, opt)


### PR DESCRIPTION
Now envutil.rb is a part of test-unit-ruby-core gem, which still supports old versions, 2.3 or later.

ruby/ruby@52287c68abd696ee7808fa231873e917d74dae7b