### PR TITLE
Fix SyntaxError: unexpected keyword_rescue, expecting keyword_end in Ruby 2.4 and earlier

### DIFF
--- a/lib/envutil.rb
+++ b/lib/envutil.rb
@@ -104,9 +104,11 @@ module EnvUtil
     else
       return unless dpid
       [[timeout, :TERM], [reprieve, :KILL]].find do |t, sig|
-        return EnvUtil.timeout(t) {Process.wait(dpid)}
-      rescue Timeout::Error
-        Process.kill(sig, dpid)
+        begin
+          return EnvUtil.timeout(t) {Process.wait(dpid)}
+        rescue Timeout::Error
+          Process.kill(sig, dpid)
+        end
       end
       true
     end


### PR DESCRIPTION
### Background

A SyntaxError (`syntax error, unexpected keyword_rescue, expecting keyword_end`) occurs in the ipaddr gem's CI when running tests with Ruby 2.4:
```sh
Run bundle exec rake test
...
/home/runner/work/ipaddr/ipaddr/vendor/bundle/ruby/2.4.0/gems/test-unit-ruby-core-1.0.9/lib/core_assertions.rb:75:in `require_relative': /home/runner/work/ipaddr/ipaddr/vendor/bundle/ruby/2.4.0/gems/test-unit-ruby-core-1.0.9/lib/envutil.rb:108: syntax error, unexpected keyword_rescue, expecting keyword_end (SyntaxError)
      rescue Timeout::Error
            ^
/home/runner/work/ipaddr/ipaddr/vendor/bundle/ruby/2.4.0/gems/test-unit-ruby-core-1.0.9/lib/envutil.rb:481: syntax error, unexpected keyword_end, expecting end-of-input
...
```
https://github.com/ruby/ipaddr/actions/runs/18297568280/job/52098942424?pr=88#step:4:16

This error occurs only with the combination of Ruby 2.4 and `test-unit-ruby-core` 1.0.9.
It does not occur on Ruby 2.5 or later.

### Details

In Ruby 2.4 and earlier, `rescue` cannot be used without an explicit `begin`/`end` block.
Therefore, this Pull Request adds the missing `begin` and `end` to fix the syntax error.