### PR TITLE
Sync tool/lib changes from ruby/ruby

### DIFF
--- a/lib/core_assertions.rb
+++ b/lib/core_assertions.rb
@@ -303,9 +303,35 @@ module Test
 
       def separated_runner(token, out = nil)
         include(*Test::Unit::TestCase.ancestors.select {|c| !c.is_a?(Class) })
+
         out = out ? IO.new(out, 'w') : STDOUT
+
+        # avoid method redefinitions
+        out_write = out.method(:write)
+        integer_to_s = Integer.instance_method(:to_s)
+        array_pack = Array.instance_method(:pack)
+        marshal_dump = Marshal.method(:dump)
+        assertions_ivar_set = Test::Unit::Assertions.method(:instance_variable_set)
+        assertions_ivar_get = Test::Unit::Assertions.method(:instance_variable_get)
+        Test::Unit::Assertions.module_eval do
+          @_assertions = 0
+
+          undef _assertions=
+          define_method(:_assertions=, ->(n) {assertions_ivar_set.call(:@_assertions, n)})
+
+          undef _assertions
+          define_method(:_assertions, -> {assertions_ivar_get.call(:@_assertions)})
+        end
+        # assume Method#call and UnboundMethod#bind_call need to work as the original
+
         at_exit {
-          out.puts "#{token}<error>", [Marshal.dump($!)].pack('m'), "#{token}</error>", "#{token}assertions=#{self._assertions}"
+          assertions = assertions_ivar_get.call(:@_assertions)
+          out_write.call <<~OUT
+          #{token}<error>
+          #{array_pack.bind_call([marshal_dump.call($!)], 'm')}
+          #{token}</error>
+          #{token}assertions=#{integer_to_s.bind_call(assertions)}
+          OUT
         }
         if defined?(Test::Unit::Runner)
           Test::Unit::Runner.class_variable_set(:@@stop_auto_run, true)
@@ -358,7 +384,9 @@ eom
         raise if $!
         abort = status.coredump? || (status.signaled? && ABORT_SIGNALS.include?(status.termsig))
         assert(!abort, FailDesc[status, nil, stderr])
-        self._assertions += res[/^#{token_re}assertions=(\d+)/, 1].to_i
+        if (assertions = res[/^#{token_re}assertions=(\d+)/, 1].to_i) > 0
+          self._assertions += assertions
+        end
         begin
           res = Marshal.load(res[/^#{token_re}<error>\n\K.*\n(?=#{token_re}<\/error>$)/m].unpack1("m"))
         rescue => marshal_error

--- a/lib/core_assertions.rb
+++ b/lib/core_assertions.rb
@@ -327,10 +327,9 @@ module Test
         at_exit {
           assertions = assertions_ivar_get.call(:@_assertions)
           out_write.call <<~OUT
-          #{token}<error>
-          #{array_pack.bind_call([marshal_dump.call($!)], 'm')}
-          #{token}</error>
-          #{token}assertions=#{integer_to_s.bind_call(assertions)}
+          <error id="#{token}" assertions=#{integer_to_s.bind_call(assertions)}>
+          #{array_pack.bind_call([marshal_dump.call($!)], 'm0')}
+          </error id="#{token}">
           OUT
         }
         if defined?(Test::Unit::Runner)
@@ -383,17 +382,17 @@ eom
         end
         raise if $!
         abort = status.coredump? || (status.signaled? && ABORT_SIGNALS.include?(status.termsig))
+        assertions = 0
+        marshal_error = nil
         assert(!abort, FailDesc[status, nil, stderr])
-        if (assertions = res[/^#{token_re}assertions=(\d+)/, 1].to_i) > 0
-          self._assertions += assertions
-        end
-        begin
-          res = Marshal.load(res[/^#{token_re}<error>\n\K.*\n(?=#{token_re}<\/error>$)/m].unpack1("m"))
+        res.scan(/^<error id="#{token_re}" assertions=(\d+)>\n(.*?)\n(?=<\/error id="#{token_re}">$)/m) do
+          assertions += $1.to_i
+          res = Marshal.load($2.unpack1("m")) or next
         rescue => marshal_error
           ignore_stderr = nil
           res = nil
-        end
-        if res and !(SystemExit === res)
+        else
+          next if SystemExit === res
           if bt = res.backtrace
             bt.each do |l|
               l.sub!(/\A-:(\d+)/){"#{file}:#{line + $1.to_i}"}
@@ -405,7 +404,7 @@ eom
           raise res
         end
 
-        # really is it succeed?
+        # really did it succeed?
         unless ignore_stderr
           # the body of assert_separately must not output anything to detect error
           assert(stderr.empty?, FailDesc[status, "assert_separately failed with error message", stderr])

--- a/lib/core_assertions.rb
+++ b/lib/core_assertions.rb
@@ -388,7 +388,7 @@ eom
 
       # Run Ractor-related test without influencing the main test suite
       def assert_ractor(src, args: [], require: nil, require_relative: nil, file: nil, line: nil, ignore_stderr: nil, **opt)
-        return unless defined?(Ractor)
+        omit unless defined?(Ractor)
 
         # https://bugs.ruby-lang.org/issues/21262
         shim_value = "class Ractor; alias value take; end" unless Ractor.method_defined?(:value)

--- a/lib/core_assertions.rb
+++ b/lib/core_assertions.rb
@@ -382,11 +382,10 @@ eom
         end
         raise if $!
         abort = status.coredump? || (status.signaled? && ABORT_SIGNALS.include?(status.termsig))
-        assertions = 0
         marshal_error = nil
         assert(!abort, FailDesc[status, nil, stderr])
         res.scan(/^<error id="#{token_re}" assertions=(\d+)>\n(.*?)\n(?=<\/error id="#{token_re}">$)/m) do
-          assertions += $1.to_i
+          self._assertions += $1.to_i
           res = Marshal.load($2.unpack1("m")) or next
         rescue => marshal_error
           ignore_stderr = nil

--- a/lib/core_assertions.rb
+++ b/lib/core_assertions.rb
@@ -909,10 +909,11 @@ eom
 
         first = seq.first
         *arg = pre.call(first)
-        times = (0..(rehearsal || (2 * first))).map do
+        raw_times = (0..(rehearsal || (2 * first))).map do
           measure[arg, "rehearsal"].nonzero?
         end
-        times.compact!
+        times = raw_times.compact
+        raise "all measurements are zero: #{raw_times.inspect}" if times.empty?
         tmin, tmax = times.minmax
 
         # safe_factor * tmax * rehearsal_time_variance_factor(equals to 1 when variance is small)

--- a/lib/envutil.rb
+++ b/lib/envutil.rb
@@ -130,7 +130,7 @@ module EnvUtil
 
     register("gdb") do
       class << self
-        def usable?; system(*%w[gdb --batch --quiet --nx -ex exit]); end
+        def usable?; system(*%w[gdb --batch --quiet --nx -ex exit], out: IO::NULL, err: IO::NULL); end
         def start(pid, *args, **opts)
           spawn(*%W[gdb --batch --quiet --pid #{pid}], *args, **opts)
         end
@@ -140,7 +140,7 @@ module EnvUtil
 
     register("lldb") do
       class << self
-        def usable?; system(*%w[lldb -Q --no-lldbinit -o exit]); end
+        def usable?; system(*%w[lldb -Q --no-lldbinit -o exit], out: IO::NULL, err: IO::NULL); end
         def start(pid, *args, **opts)
           spawn(*%W[lldb --batch -Q --attach-pid #{pid}], *args, **opts)
         end
@@ -149,7 +149,10 @@ module EnvUtil
     end
 
     def self.search
-      @debugger ||= @list.find(&:usable?)
+      # Cache the result even when no debugger is available, not to probe
+      # unusable debuggers repeatedly.
+      return @debugger if defined?(@debugger)
+      @debugger = @list.find(&:usable?)
     end
   end
 

--- a/lib/envutil.rb
+++ b/lib/envutil.rb
@@ -290,7 +290,7 @@ module EnvUtil
   module_function :invoke_ruby
 
   def current_parser
-    features = RUBY_DESCRIPTION[%r{\)\K [-+*/%._0-9a-zA-Z ]*(?=\[[-+*/%._0-9a-zA-Z]+\]\z)}]
+    features = RUBY_DESCRIPTION[%r{\)\K [-+*/%._0-9a-zA-Z\[\] ]*(?=\[[-+*/%._0-9a-zA-Z]+\]\z)}]
     features&.split&.include?("+PRISM") ? "prism" : "parse.y"
   end
   module_function :current_parser


### PR DESCRIPTION
`EnvUtil::Debugger.search` runs each debugger to test whether it is usable, and the probe output goes straight into the test output. On Windows the lldb bundled with Visual Studio BuildTools fails to delay-load `python311.dll` and dumps an LLVM crash report over the test progress line. The probes now redirect to `IO::NULL`, and a nil result is cached so the failing probe does not repeat on every timeout.

Checking that the next sync would not revert this, I found six more changes ruby/ruby has and this repository lacks, so they are forward-ported here with their original authors. The files under `lib` now match `tool/lib` except for `-W:no-experimental`, which f805db3 deliberately reverted. Note that `rake sync_tool` copies verbatim and will restore that line, and the ported code needs Ruby 2.7 for `UnboundMethod#bind_call` while `required_ruby_version` still says 2.3.
