### PR TITLE
Unset PAGER environment variables when reading the help message

### DIFF
--- a/lib/envutil.rb
+++ b/lib/envutil.rb
@@ -239,7 +239,7 @@ module EnvUtil
     args = [args] if args.kind_of?(String)
     # use the same parser as current ruby
     if (args.none? { |arg| arg.start_with?("--parser=") } and
-        /^ +--parser=/ =~ IO.popen([rubybin, "--help"], &:read))
+        /^ +--parser=/ =~ IO.popen([{"PAGER"=>nil, "RUBY_PAGER"=>nil}, rubybin, "--help", err: %i[child out]], &:read))
       args = ["--parser=#{current_parser}"] + args
     end
     pid = spawn(child_env, *precommand, rubybin, *args, opt)


### PR DESCRIPTION
Workaround for jruby/jruby#9026.  JRuby attempts to call the entire `ENV[“PAGER”]` (or `ENV["RUBY_PAGER"]`) as the program name instead of splitting it into a program name and options, even if stdout and stderr are redirected to a non-tty.