### PR TITLE
Fix SyntaxError: unexpected keyword_rescue, expecting keyword_end in Ruby 2.4 and earlier

### DIFF
--- a/lib/core_assertions.rb
+++ b/lib/core_assertions.rb
@@ -386,21 +386,23 @@ eom
         assert(!abort, FailDesc[status, nil, stderr])
         res.scan(/^<error id="#{token_re}" assertions=(\d+)>\n(.*?)\n(?=<\/error id="#{token_re}">$)/m) do
           self._assertions += $1.to_i
-          res = Marshal.load($2.unpack1("m")) or next
-        rescue => marshal_error
-          ignore_stderr = nil
-          res = nil
-        else
-          next if SystemExit === res
-          if bt = res.backtrace
-            bt.each do |l|
-              l.sub!(/\A-:(\d+)/){"#{file}:#{line + $1.to_i}"}
-            end
-            bt.concat(caller)
+          begin
+            res = Marshal.load($2.unpack1("m")) or next
+          rescue => marshal_error
+            ignore_stderr = nil
+            res = nil
           else
-            res.set_backtrace(caller)
+            next if SystemExit === res
+            if bt = res.backtrace
+              bt.each do |l|
+                l.sub!(/\A-:(\d+)/){"#{file}:#{line + $1.to_i}"}
+              end
+              bt.concat(caller)
+            else
+              res.set_backtrace(caller)
+            end
+            raise res
           end
-          raise res
         end
 
         # really did it succeed?


### PR DESCRIPTION
### Background

A SyntaxError (`syntax error, unexpected keyword_rescue, expecting keyword_end`) occurs in the ipaddr gem's CI when running tests with Ruby 2.4:
```sh
Run bundle exec rake test
...
/opt/hostedtoolcache/Ruby/2.4.10/x64/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:133:in `require': /home/runner/work/ipaddr/ipaddr/vendor/bundle/ruby/2.4.0/gems/test-unit-ruby-core-1.0.15/lib/core_assertions.rb:390: syntax error, unexpected keyword_rescue, expecting keyword_end (SyntaxError)
        rescue => marshal_error
              ^
/home/runner/work/ipaddr/ipaddr/vendor/bundle/ruby/2.4.0/gems/test-unit-ruby-core-1.0.15/lib/core_assertions.rb:393: syntax error, unexpected keyword_else, expecting keyword_end
        else
            ^
/home/runner/work/ipaddr/ipaddr/vendor/bundle/ruby/2.4.0/gems/test-unit-ruby-core-1.0.15/lib/core_assertions.rb:1032: syntax error, unexpected keyword_end, expecting end-of-input
...
```
https://github.com/ruby/ipaddr/actions/runs/31352885261/job/93346878646#step:4:11

This error occurs only with the combination of Ruby 2.4 and `test-unit-ruby-core` v1.0.15.
It does not occur on Ruby 2.5 or later.

- https://github.com/ruby/ipaddr/issues/119

### Details

This Pull Request adds the missing `begin` and `end` to fix the syntax error.